### PR TITLE
feat: add support for options of `gas-entry-generator`

### DIFF
--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -2,6 +2,7 @@ import { join } from "path";
 
 import type {
   FuncPluginConfig,
+  NotNullRollupPluginGasOptions,
   PluginOptions,
   RollupPluginGasOptions,
 } from "types";
@@ -10,17 +11,26 @@ const getPluginSettings = <T extends PluginOptions>(
   defaultOptions: T,
   inputOptions?: PluginOptions
 ): FuncPluginConfig<T> => {
-  return Object.assign({}, defaultOptions, inputOptions) as FuncPluginConfig<T>;
+  return Object.assign(
+    {},
+    defaultOptions,
+    inputOptions
+  ) as unknown as FuncPluginConfig<T>;
 };
 
 const getPluginSetting = (options?: RollupPluginGasOptions) => {
-  const defaultOptions = {
-    comment: false,
+  const defaultOptions: NotNullRollupPluginGasOptions = {
     include: ["**/*"],
     moduleHeaderComment: false,
     manifest: {
       copy: false,
       srcDir: process.cwd(),
+    },
+    gasEntryOptions: {
+      comment: false,
+      // autoGlobalExports: false,
+      // exportsIdentifierName: "exports",
+      // globalIdentifierName: "global",
     },
     verbose: false,
   };
@@ -37,6 +47,10 @@ const getPluginSetting = (options?: RollupPluginGasOptions) => {
   configuredOptions.manifest = getPluginSettings(
     defaultOptions.manifest,
     options.manifest
+  );
+  configuredOptions.gasEntryOptions = getPluginSettings(
+    defaultOptions.gasEntryOptions,
+    options.gasEntryOptions
   );
 
   return configuredOptions;

--- a/src/plugin-entry-point.ts
+++ b/src/plugin-entry-point.ts
@@ -2,9 +2,8 @@ import { basename } from "path";
 
 import pc from "picocolors";
 import { createFilter } from "rollup-pluginutils";
-import { generate } from "gas-entry-generator";
 
-import { getRelativePath } from "@/plugin-utils";
+import { getRelativePath, generateEntry } from "@/plugin-utils";
 
 import type { Plugin } from "rollup";
 import type { NotNullRollupPluginGasOptions } from "types";
@@ -45,7 +44,7 @@ const rollupPluginGasEntryPoint = (
       this.info(
         pc.gray("Generated entry points for: ") + pc.green(getRelativePath(id))
       );
-      const gasCode = generate(code, { comment: configuratedOptions.comment });
+      const gasCode = generateEntry(code, configuratedOptions.gasEntryOptions);
       if (gasCode.entryPointFunctions) {
         const codes = String(gasCode.entryPointFunctions).replace(
           /{\n}/g,

--- a/src/plugin-utils.ts
+++ b/src/plugin-utils.ts
@@ -1,5 +1,12 @@
 import path from "path";
 
+import { generate } from "gas-entry-generator";
+
+import type { GasEntryOptions } from "types";
+
 export const getRelativePath = (filePath: string): string => {
   return [".", path.relative(process.cwd(), filePath)].join(path.sep);
 };
+
+export const generateEntry = (code: string, prams: GasEntryOptions) =>
+  generate(code, prams);

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -1,0 +1,66 @@
+import path from "path";
+
+import { rollup } from "rollup";
+
+import rollupPluginGas from "@/index";
+import getPluginSetting from "@/plugin-config";
+import * as gasEntryGenerator from "@/plugin-utils";
+
+describe("Configration Test", () => {
+  const expected = {
+    include: ["**/*"],
+    moduleHeaderComment: false,
+    manifest: {
+      copy: false,
+      srcDir: process.cwd(),
+    },
+    gasEntryOptions: { comment: false },
+    verbose: false,
+  };
+
+  it("default", () => {
+    const result = getPluginSetting();
+    assert.deepEqual(expected, result);
+  });
+
+  it("gasOptions", () => {
+    const expectedGasEntryOption = {
+      comment: true,
+      exportsIdentifierName: "exports",
+      autoGlobalExports: true,
+      globalIdentifierName: "global",
+    };
+    const result = getPluginSetting({
+      gasEntryOptions: expectedGasEntryOption,
+    });
+    const _expected = expected;
+    _expected.gasEntryOptions = expectedGasEntryOption;
+
+    assert.deepEqual(_expected, result);
+  });
+
+  it("test", async () => {
+    const spy = vi.spyOn(gasEntryGenerator, "generateEntry");
+
+    const dirnameFixtures = "./__fixtures__";
+    const dirFixtures = path.resolve(__dirname, dirnameFixtures);
+
+    const gasEntryOptions = {
+      comment: true,
+      autoGlobalExports: true,
+      exportsIdentifierName: "exportsZ",
+      globalIdentifierName: "globalZ",
+    };
+    const options = {
+      gasEntryOptions,
+    };
+    const bundle = await rollup({
+      input: path.join(dirFixtures, `basic.js`),
+      plugins: [rollupPluginGas(options)],
+      logLevel: "info",
+    });
+
+    await bundle.generate({});
+    assert.deepEqual(spy.mock.calls[0][1], gasEntryOptions);
+  });
+});

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -77,7 +77,7 @@ describe("rollup-plugin-gas", () => {
   it("Should include comments", async () => {
     await buildAndAssertOutput(
       { scenario: "comment", dirFixtures: dirFixtures },
-      { comment: true }
+      { gasEntryOptions: { comment: true } }
     );
   });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,28 +3,47 @@ export interface ManifestOptions {
   srcDir?: string;
 }
 
-export interface RollupPluginGasOptions {
+export interface GasEntryOptions {
   comment?: boolean;
+  autoGlobalExports?: boolean;
+  exportsIdentifierName?: string;
+  globalIdentifierName?: string;
+}
+export interface DefaultGasEntryOptions {
+  comment: boolean;
+  autoGlobalExports?: boolean;
+  exportsIdentifierName?: string;
+  globalIdentifierName?: string;
+}
+
+export interface RollupPluginGasOptions {
   include?: Array<string>;
   moduleHeaderComment?: boolean;
   manifest?: ManifestOptions;
+  gasEntryOptions?: GasEntryOptions;
   verbose?: boolean;
 }
 
-type DeepRequired<T> = {
-  [K in keyof T]-?: Required<DeepRequired<T[K]>>;
+export type NotNullRollupPluginGasOptions = {
+  include: Array<string>;
+  moduleHeaderComment: boolean;
+  manifest: Required<ManifestOptions>;
+  gasEntryOptions: DefaultGasEntryOptions;
+  verbose: boolean;
 };
 
-export type NotNullRollupPluginGasOptions =
-  DeepRequired<RollupPluginGasOptions>;
+export type NotNullManifestOptions = Required<ManifestOptions>;
 
-export type NotNullManifestOptions = DeepRequired<ManifestOptions>;
-
-export type PluginOptions = RollupPluginGasOptions | ManifestOptions;
+export type PluginOptions =
+  | RollupPluginGasOptions
+  | ManifestOptions
+  | GasEntryOptions;
 
 export type FuncPluginConfig<T> = T extends RollupPluginGasOptions
   ? NotNullRollupPluginGasOptions
-  : NotNullManifestOptions;
+  : T extends GasEntryOptions
+    ? DefaultGasEntryOptions
+    : NotNullManifestOptions;
 
 export default function rollupPluginGas(
   options?: RollupPluginGasOptions


### PR DESCRIPTION
modifies the plugin options structure to allow specifying options for
`gas-entry-generator`.The new structure enhances flexibility in
configuration, making it easier to customize and fine-tune the plugin's
behavior.

BREAKING CHANGE: plugin options structure was changed. remove `comment` option insted of
use `gasEntryOptions.comment`.

Closes: #218
